### PR TITLE
Update README: F-Droid and PlayStore downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This application tries to be 100% compatible with [pass](http://www.passwordstor
 
 You can install the application from:
 
-- [F-Droid](https://f-droid.org/repository/browse/?fdid=com.zeapo.pwdstore) (the prefered way)
-- [Play Store](https://play.google.com/store/apps/details?id=com.zeapo.pwdstore) (always lags behind)
+- [F-Droid](https://f-droid.org/repository/browse/?fdid=com.zeapo.pwdstore)
+- [Play Store](https://play.google.com/store/apps/details?id=com.zeapo.pwdstore)
 
 Pull requests are more than welcome (see [TODO](https://github.com/zeapo/Android-Password-Store/projects/1#column-228844)).
 


### PR DESCRIPTION
v1.3.3 has been released a week ago and can be installed via PlayStore (beta branch). The F-Droid version hasn't been updated yet, so I think it's no longer fair to call the PlayStore version "always lagging behind".